### PR TITLE
Ordenando facturas por fecha de forma descendente

### DIFF
--- a/APS.Web/Views/Factura/Index.cshtml
+++ b/APS.Web/Views/Factura/Index.cshtml
@@ -41,7 +41,7 @@
                         <tr>
                             <td>@factura.NombreCliente</td>
                             <td>@factura.DireccionCliente</td>
-                            <td>@factura.Fecha.ToString("dd/MM/yyyy")</td>
+                            <td data-order="@factura.Fecha.Ticks">@factura.Fecha.ToString("dd/MM/yyyy")</td>
                             <td>₡@factura.Total.ToString("N2")</td>
                             <td>₡@totalConIVA.ToString("N2")</td>
                             <td>

--- a/APS.Web/Views/Shared/_AdminLayout.cshtml
+++ b/APS.Web/Views/Shared/_AdminLayout.cshtml
@@ -143,7 +143,7 @@
                 },
                 "pageLength": 10,
                 "lengthMenu": [5, 10, 20, 50],
-                "order": [[2, "asc"]]
+                "order": [[2, "desc"]]
             });
         });
 

--- a/APS.Web/Views/Shared/_AdminLayout.cshtml
+++ b/APS.Web/Views/Shared/_AdminLayout.cshtml
@@ -143,7 +143,7 @@
                 },
                 "pageLength": 10,
                 "lengthMenu": [5, 10, 20, 50],
-                "order": [[0, "asc"]]
+                "order": [[2, "asc"]]
             });
         });
 


### PR DESCRIPTION
Ordenando facturas por fecha de forma descendente

y configuracion datatables para empezar de forma descendente y tomar en cuenta el tick de cada fecha para evitar comparaciones por texto resultando en orden incorrecto